### PR TITLE
Port to Swift 4.1, Xcode 9.3, and iOS 11

### DIFF
--- a/UIScrollViewWithAutoLayout.xcodeproj/project.pbxproj
+++ b/UIScrollViewWithAutoLayout.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "UIScrollViewWithAutoLayout/UIScrollViewWithAutoLayout-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -277,6 +278,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.atomicobject.UIScrollViewWithAutoLayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "UIScrollViewWithAutoLayout/UIScrollViewWithAutoLayout-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/UIScrollViewWithAutoLayout/SCRViewControllerSwift.swift
+++ b/UIScrollViewWithAutoLayout/SCRViewControllerSwift.swift
@@ -16,40 +16,39 @@ class SCRViewControllerSwift: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardDidShow:", name: UIKeyboardDidShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillBeHidden:", name: UIKeyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(SCRViewControllerSwift.keyboardDidShow),
+            name: .UIKeyboardDidShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(SCRViewControllerSwift.keyboardWillBeHidden),
+            name: .UIKeyboardWillHide, object: nil)
     }
    
-    func textFieldShouldReturn(textField: UITextField) -> Bool {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
     }
     
-    func textFieldDidEndEditing(textField: UITextField) {
-        self.activeField = nil
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        activeField = nil
     }
     
-    func textFieldDidBeginEditing(textField: UITextField) {
-        self.activeField = textField
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        activeField = textField
     }
     
-    func keyboardDidShow(notification: NSNotification) {
-        if let activeField = self.activeField, keyboardSize = (notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.CGRectValue() {
-            let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height, right: 0.0)
-            self.scrollView.contentInset = contentInsets
-            self.scrollView.scrollIndicatorInsets = contentInsets
-            var aRect = self.view.frame
-            aRect.size.height -= keyboardSize.size.height
-            if (!CGRectContainsPoint(aRect, activeField.frame.origin)) {
-                self.scrollView.scrollRectToVisible(activeField.frame, animated: true)
-            }
-        }
+    @objc func keyboardDidShow(notification: Notification) {
+        guard let keyboardSize = (notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue else { return }
+        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height, right: 0.0)
+        scrollView.contentInset = contentInsets
+        scrollView.scrollIndicatorInsets = contentInsets
+        guard let activeField = activeField else { return }
+        let activeRect = activeField.convert(activeField.bounds, to: scrollView)
+        scrollView.scrollRectToVisible(activeRect, animated: true)
     }
     
-    func keyboardWillBeHidden(notification: NSNotification) {
-        let contentInsets = UIEdgeInsetsZero
-        self.scrollView.contentInset = contentInsets
-        self.scrollView.scrollIndicatorInsets = contentInsets
+    @objc func keyboardWillBeHidden(notification: Notification) {
+        let contentInsets = UIEdgeInsets.zero
+        scrollView.contentInset = contentInsets
+        scrollView.scrollIndicatorInsets = contentInsets
     }
 }
 


### PR DESCRIPTION
Thanks for this repo and the associated article. Very helpful! 

I thought as long as I was scrutinizing it, I would convert it to the current API. It's mostly just mechanical changes, but I did make a couple of tweaks in keyboardDidShow():

1) I don't think you need to check for visibility before scrolling (or at least, not anymore) since UIScrollView.scrollRectToVisible does nothing if the rect is already visible.

2) The argument to scrollRectToVisible should be in the scrollRect's coordinate system. The current code works fine given that the coordinate systems are all aligned, but since it's an example you may as well show formal conversion. 

3) I didn't make this change, but UITextFields seem to scroll themselves into view automatically when they are activated. Just doing activeField.becomeFirstResponder() seems to achieve the same scrolling result without having to fuss with any rects.